### PR TITLE
Pining Version for importlib-metadata venv fix

### DIFF
--- a/environment_dev.yml
+++ b/environment_dev.yml
@@ -20,3 +20,4 @@ dependencies:
     - coverage==4.5.3               #dev
     - flake8==3.7.7                 #dev
     - redis==3.2.1
+    - importlib-metadata==4.13.0

--- a/orders/setup.py
+++ b/orders/setup.py
@@ -12,6 +12,7 @@ setup(
         'alembic==1.0.10',
         'marshmallow==2.19.2',
         'psycopg2-binary==2.8.2',
+        'importlib-metadata<=4.13.0',
     ],
     extras_require={
         'dev': [


### PR DESCRIPTION
Error: 
  File "/usr/local/Caskroom/miniconda/base/envs/nameko-devex/lib/python3.7/site-packages/kombu/utils/compat.py", line 93, in entrypoints
    for ep in importlib_metadata.entry_points().get(namespace, [])
AttributeError: 'EntryPoints' object has no attribute 'get' Latest version of importlib returns tuple instead of list K8s fix will be separate