### PR TITLE
Fixing performance issue in order creation

### DIFF
--- a/gateway/gateway/service.py
+++ b/gateway/gateway/service.py
@@ -94,7 +94,10 @@ class GatewayService(object):
         order = self.orders_rpc.get_order(order_id)
 
         # Retrieve all products from the products service
-        product_map = {prod['id']: prod for prod in self.products_rpc.list()}
+        ids = [order['product_id'] for order in order['order_details']]
+
+        product_map = {
+            prod['id']: prod for prod in self.products_rpc.list(ids)}
 
         # get the configured image root
         image_root = config['PRODUCT_IMAGE_ROOT']
@@ -157,12 +160,18 @@ class GatewayService(object):
 
     def _create_order(self, order_data):
         # check order product ids are valid
-        valid_product_ids = {prod['id'] for prod in self.products_rpc.list()}
-        for item in order_data['order_details']:
-            if item['product_id'] not in valid_product_ids:
-                raise ProductNotFound(
-                    "Product Id {}".format(item['product_id'])
-                )
+        order_product_ids = [order['product_id'] for order in order_data['order_details']]
+        existing_product_ids = [prod['id']
+                                for prod in self.products_rpc.list(order_product_ids) if prod]
+
+        non_existing_products_ids = [
+            id for id in order_product_ids if id not in existing_product_ids]
+
+        if non_existing_products_ids:
+            raise ProductNotFound(
+                "Product Ids {}".format([str(id)
+                                         for id in non_existing_products_ids])
+            )
 
         # Call orders-service to create the order.
         # Dump the data through the schema to ensure the values are serialized

--- a/gateway/test/interface/test_service.py
+++ b/gateway/test/interface/test_service.py
@@ -164,7 +164,8 @@ class TestGetOrder(object):
 
         # check dependencies called as expected
         assert [call(1)] == gateway_service.orders_rpc.get_order.call_args_list
-        assert [call()] == gateway_service.products_rpc.list.call_args_list
+        assert [call(['the_odyssey', 'the_enigma'])
+                ] == gateway_service.products_rpc.list.call_args_list
 
     def test_order_not_found(self, gateway_service, web_session):
         gateway_service.orders_rpc.get_order.side_effect = (
@@ -220,7 +221,8 @@ class TestCreateOrder(object):
         )
         assert response.status_code == 200
         assert response.json() == {'id': 11}
-        assert gateway_service.products_rpc.list.call_args_list == [call()]
+        assert gateway_service.products_rpc.list.call_args_list == [
+            call(['the_odyssey'])]
         assert gateway_service.orders_rpc.create_order.call_args_list == [
             call([
                 {'product_id': 'the_odyssey', 'quantity': 3, 'price': '41.00'}
@@ -291,4 +293,4 @@ class TestCreateOrder(object):
         )
         assert response.status_code == 404
         assert response.json()['error'] == 'PRODUCT_NOT_FOUND'
-        assert response.json()['message'] == 'Product Id unknown'
+        assert response.json()['message'] == "Product Ids ['unknown']"

--- a/products/products/dependencies.py
+++ b/products/products/dependencies.py
@@ -43,10 +43,17 @@ class StorageWrapper:
         else:
             return self._from_hash(product)
 
-    def list(self):
-        keys = self.client.keys(self._format_key('*'))
+    def list(self, product_ids):
+        if product_ids:
+            keys = [self._format_key(product_id) for product_id in product_ids]
+        else:
+            keys = self.client.keys(self._format_key('*'))
+
         for key in keys:
-            yield self._from_hash(self.client.hgetall(key))
+            document = self.client.hgetall(key)
+            if document :
+                yield self._from_hash(document)
+
 
     def create(self, product):
         self.client.hmset(

--- a/products/products/service.py
+++ b/products/products/service.py
@@ -21,8 +21,8 @@ class ProductsService:
         return schemas.Product().dump(product).data
 
     @rpc
-    def list(self):
-        products = self.storage.list()
+    def list(self, product_ids=[]):
+        products = self.storage.list(product_ids)
         return schemas.Product(many=True).dump(products).data
 
     @rpc

--- a/products/test/test_dependencies.py
+++ b/products/test/test_dependencies.py
@@ -28,10 +28,22 @@ def test_get(storage, products):
     assert 11 == product['in_stock']
 
 
-def test_list(storage, products):
-    listed_products = storage.list()
+def test_list_without_filter(storage, products):
+    listed_products = storage.list([])
     assert (
         products == sorted(list(listed_products), key=lambda x: x['id']))
+
+
+def test_list_with_one_filter(storage, products):
+    listed_products = list(storage.list(['LZ130']))
+    assert listed_products[0]['id'] == 'LZ130'
+
+
+def test_list_with_two_filters(storage, products):
+    listed_products = list(storage.list(['LZ130', 'LZ127']))
+
+    assert any(prod['id'] == 'LZ130' for prod in listed_products)
+    assert any(prod['id'] == 'LZ127' for prod in listed_products)
 
 
 def test_create(product, redis_client, storage):


### PR DESCRIPTION
## Problem:

Order creation flow makes a RPC call to the product service and always lists all the products in the database. 
The main problem is: the service gets the products from Redis one by one. When the number of registered products increases, the product service takes longer to generate the response back to the order service, and considering RPC calls as blocking calls, the system starts to have a lot of calls being processed at the same time, and the time becomes bigger and bigger.

## Solution:

Add a filter param to `ProductsService.list(self, product_ids=[])` to list only the desired products, if the list is empty, then list all the products.

## Attention points:

The error message in order creation was updated we need to check if someone uses this API and the new message works as well as the old one.

## Performance test

![nameko-performace](https://github.com/gitricko/nameko-devex/assets/54643665/27ae1f11-6e2a-436e-bb90-c0334af97f20)
