### PR TITLE
Ricardo - Ilia Code Challenge

### DIFF
--- a/gateway/gateway/schemas.py
+++ b/gateway/gateway/schemas.py
@@ -33,3 +33,9 @@ class GetOrderSchema(Schema):
 
     id = fields.Int()
     order_details = fields.Nested(OrderDetail, many=True)
+
+class ListOrdersSchema(Schema):
+    page = fields.Int()
+    page_size = fields.Int()
+    total = fields.Int()
+    items = fields.Nested(GetOrderSchema, many=True)

--- a/gateway/gateway/service.py
+++ b/gateway/gateway/service.py
@@ -69,9 +69,9 @@ class GatewayService(object):
             raise BadRequest("Invalid json: {}".format(exc))
 
         # Create the product
-        self.products_rpc.create(product_data)
+        product = self.products_rpc.create(product_data)
         return Response(
-            json.dumps({'id': product_data['id']}), mimetype='application/json'
+            json.dumps({'id': product['id']}), mimetype='application/json'
         )
 
     @http(

--- a/gateway/gateway/service.py
+++ b/gateway/gateway/service.py
@@ -73,6 +73,23 @@ class GatewayService(object):
         return Response(
             json.dumps({'id': product_data['id']}), mimetype='application/json'
         )
+    
+    @http(
+        "DELETE", "/products/<string:product_id>",
+        expected_exceptions=ProductNotFound
+    )
+    def delete_product(self, request, product_id):
+        """Delete product by `product_id`
+
+        The response contains the deleted product ID in a json document ::
+
+            {"id": "the_odyssey"}
+
+        """
+        self.products_rpc.delete(product_id)
+        return Response(
+            json.dumps({'id': product_id}), mimetype='application/json'
+        )
 
     @http("GET", "/orders/<int:order_id>", expected_exceptions=OrderNotFound)
     def get_order(self, request, order_id):

--- a/gateway/test/interface/test_service.py
+++ b/gateway/test/interface/test_service.py
@@ -54,12 +54,12 @@ class TestCreateProduct(object):
         assert response.status_code == 200
         assert response.json() == {'id': 'the_odyssey'}
         assert gateway_service.products_rpc.create.call_args_list == [call({
-                "in_stock": 10,
-                "maximum_speed": 5,
-                "id": "the_odyssey",
-                "passenger_capacity": 101,
-                "title": "The Odyssey"
-            })]
+            "in_stock": 10,
+            "maximum_speed": 5,
+            "id": "the_odyssey",
+            "passenger_capacity": 101,
+            "title": "The Odyssey"
+        })]
 
     def test_create_product_fails_with_invalid_json(
         self, gateway_service, web_session
@@ -80,9 +80,11 @@ class TestCreateProduct(object):
         assert response.status_code == 400
         assert response.json()['error'] == 'VALIDATION_ERROR'
 
+
 class TestDeletetProduct(object):
     def test_can_delete_product(self, gateway_service, web_session):
-        gateway_service.products_rpc.delete.return_value = {"id": "the_odyssey"}
+        gateway_service.products_rpc.delete.return_value = {
+            "id": "the_odyssey"}
 
         response = web_session.delete('/products/the_odyssey')
         assert response.status_code == 200
@@ -101,6 +103,7 @@ class TestDeletetProduct(object):
         payload = response.json()
         assert payload['error'] == 'PRODUCT_NOT_FOUND'
         assert payload['message'] == 'missing'
+
 
 class TestGetOrder(object):
     def test_can_get_order(self, gateway_service, web_session):
@@ -184,7 +187,8 @@ class TestGetOrder(object):
 
         # check dependencies called as expected
         assert [call(1)] == gateway_service.orders_rpc.get_order.call_args_list
-        assert [call()] == gateway_service.products_rpc.list.call_args_list
+        assert [call(product_ids=['the_odyssey', 'the_enigma'])
+                ] == gateway_service.products_rpc.list.call_args_list
 
     def test_order_not_found(self, gateway_service, web_session):
         gateway_service.orders_rpc.get_order.side_effect = (
@@ -196,6 +200,7 @@ class TestGetOrder(object):
         payload = response.json()
         assert payload['error'] == 'ORDER_NOT_FOUND'
         assert payload['message'] == 'missing'
+
 
 class TestListOrders(object):
     def test_can_list_orders(self, gateway_service, web_session):
@@ -223,6 +228,24 @@ class TestListOrders(object):
             }]
         }
 
+        # setup mock products-service response:
+        gateway_service.products_rpc.list.return_value = [
+            {
+                'id': 'the_odyssey',
+                'title': 'The Odyssey',
+                'maximum_speed': 3,
+                'in_stock': 899,
+                'passenger_capacity': 100
+            },
+            {
+                'id': 'the_enigma',
+                'title': 'The Enigma',
+                'maximum_speed': 200,
+                'in_stock': 1,
+                'passenger_capacity': 4
+            },
+        ]
+
         # call the gateway service to list orders
         response = web_session.get('/orders')
         assert response.status_code == 200
@@ -238,12 +261,30 @@ class TestListOrders(object):
                         'id': 1,
                         'quantity': 2,
                         'product_id': 'the_odyssey',
+                        'image':
+                        'http://example.com/airship/images/the_odyssey.jpg',
+                        'product': {
+                            'id': 'the_odyssey',
+                            'title': 'The Odyssey',
+                            'maximum_speed': 3,
+                            'in_stock': 899,
+                            'passenger_capacity': 100
+                        },
                         'price': '200.00'
                     },
                     {
                         'id': 2,
                         'quantity': 1,
                         'product_id': 'the_enigma',
+                        'image':
+                        'http://example.com/airship/images/the_enigma.jpg',
+                        'product': {
+                            'id': 'the_enigma',
+                            'title': 'The Enigma',
+                            'maximum_speed': 200,
+                            'in_stock': 1,
+                            'passenger_capacity': 4
+                        },
                         'price': '400.00'
                     }
                 ]
@@ -252,7 +293,10 @@ class TestListOrders(object):
         assert expected_response == response.json()
 
         # check dependencies called with default pagination as expected
-        assert [call(page=1, page_size=30)] == gateway_service.orders_rpc.list_orders.call_args_list
+        assert [call(page=1, page_size=30)
+                ] == gateway_service.orders_rpc.list_orders.call_args_list
+        assert [call(product_ids=['the_odyssey', 'the_enigma'])
+                ] == gateway_service.products_rpc.list.call_args_list
 
     def test_can_list_orders_with_pagination(self, gateway_service, web_session):
         # setup mock orders-service response:
@@ -276,7 +320,8 @@ class TestListOrders(object):
         assert expected_response == response.json()
 
         # check dependencies called with pagination as expected
-        assert [call(page=2, page_size=60)] == gateway_service.orders_rpc.list_orders.call_args_list
+        assert [call(page=2, page_size=60)
+                ] == gateway_service.orders_rpc.list_orders.call_args_list
 
 
 class TestCreateOrder(object):
@@ -290,20 +335,17 @@ class TestCreateOrder(object):
                 'maximum_speed': 3,
                 'in_stock': 899,
                 'passenger_capacity': 100
-            },
-            {
-                'id': 'the_enigma',
-                'title': 'The Enigma',
-                'maximum_speed': 200,
-                'in_stock': 1,
-                'passenger_capacity': 4
-            },
+            }
         ]
 
         # setup mock create response
         gateway_service.orders_rpc.create_order.return_value = {
             'id': 11,
-            'order_details': []
+            'order_details': [{
+                'product_id': 'the_odyssey',
+                'price': '41.00',
+                'quantity': 3
+            }]
         }
 
         # call the gateway service to create the order
@@ -321,12 +363,16 @@ class TestCreateOrder(object):
         )
         assert response.status_code == 200
         assert response.json() == {'id': 11}
-        assert gateway_service.products_rpc.list.call_args_list == [call()]
+        assert gateway_service.products_rpc.list.call_args_list == [
+            call(product_ids=['the_odyssey'])]
         assert gateway_service.orders_rpc.create_order.call_args_list == [
             call([
                 {'product_id': 'the_odyssey', 'quantity': 3, 'price': '41.00'}
             ])
         ]
+        gateway_service.orders_rpc.create_order.assert_called_with([
+            {'product_id': 'the_odyssey', 'quantity': 3, 'price': '41.00'}
+        ])
 
     def test_create_order_fails_with_invalid_json(
         self, gateway_service, web_session

--- a/gateway/test/interface/test_service.py
+++ b/gateway/test/interface/test_service.py
@@ -80,9 +80,29 @@ class TestCreateProduct(object):
         assert response.status_code == 400
         assert response.json()['error'] == 'VALIDATION_ERROR'
 
+class TestDeletetProduct(object):
+    def test_can_delete_product(self, gateway_service, web_session):
+        gateway_service.products_rpc.delete.return_value = {"id": "the_odyssey"}
+
+        response = web_session.delete('/products/the_odyssey')
+        assert response.status_code == 200
+        assert gateway_service.products_rpc.delete.call_args_list == [
+            call("the_odyssey")
+        ]
+        assert response.json() == {"id": "the_odyssey"}
+
+    def test_product_not_found(self, gateway_service, web_session):
+        gateway_service.products_rpc.delete.side_effect = (
+            ProductNotFound('missing'))
+
+        # call the gateway service to get order #1
+        response = web_session.delete('/products/foo')
+        assert response.status_code == 404
+        payload = response.json()
+        assert payload['error'] == 'PRODUCT_NOT_FOUND'
+        assert payload['message'] == 'missing'
 
 class TestGetOrder(object):
-
     def test_can_get_order(self, gateway_service, web_session):
         # setup mock orders-service response:
         gateway_service.orders_rpc.get_order.return_value = {

--- a/orders/orders/service.py
+++ b/orders/orders/service.py
@@ -21,6 +21,22 @@ class OrdersService:
             raise NotFound('Order with id {} not found'.format(order_id))
 
         return OrderSchema().dump(order).data
+    
+    @rpc
+    def list_orders(self, page=1, page_size=30):
+        # Calculate offset by page number and page size information
+        offset = (page - 1) * page_size
+
+        orders = self.db.query(Order).offset(offset).limit(page_size)
+        total = self.db.query(Order).count()
+
+        # Return a dictionary that contains the pagination result
+        return {
+            'page': page,
+            'page_size': page_size,
+            'total': total,
+            'items': OrderSchema(many=True).dump(orders).data
+        }
 
     @rpc
     def create_order(self, order_details):

--- a/orders/orders/service.py
+++ b/orders/orders/service.py
@@ -21,7 +21,17 @@ class OrdersService:
             raise NotFound('Order with id {} not found'.format(order_id))
 
         return OrderSchema().dump(order).data
-    
+
+    @rpc
+    def get_order_by_product_id(self, product_id):
+        order = self.db.query(Order).join(OrderDetail).filter(
+            OrderDetail.product_id == product_id).first()
+        
+        if not order:
+            return None
+        
+        return OrderSchema().dump(order).data
+
     @rpc
     def list_orders(self, page=1, page_size=30):
         # Calculate offset by page number and page size information

--- a/orders/test/interface/test_service.py
+++ b/orders/test/interface/test_service.py
@@ -30,7 +30,7 @@ def order_details(db_session, order):
 
 
 def test_get_order(orders_rpc, order):
-    response = orders_rpc.get_order(1)
+    response = orders_rpc.get_order(order.id)
     assert response['id'] == order.id
 
 
@@ -39,6 +39,21 @@ def test_will_raise_when_order_not_found(orders_rpc):
     with pytest.raises(RemoteError) as err:
         orders_rpc.get_order(1)
     assert err.value.value == 'Order with id 1 not found'
+
+def test_list_orders(orders_rpc, order):
+    response = orders_rpc.list_orders()
+    assert response['items'][0]['id'] == order.id
+
+    # Check response default pagination values
+    assert response['page'] == 1
+    assert response['page_size'] == 30
+    assert response['total'] == 1
+
+def test_list_orders_with_custom_pagination(orders_rpc, order):
+    response = orders_rpc.list_orders(page=2, page_size=3)
+    assert response['page'] == 2
+    assert response['page_size'] == 3
+    assert response['total'] == 1
 
 
 @pytest.mark.usefixtures('db_session')

--- a/orders/test/interface/test_service.py
+++ b/orders/test/interface/test_service.py
@@ -40,6 +40,14 @@ def test_will_raise_when_order_not_found(orders_rpc):
         orders_rpc.get_order(1)
     assert err.value.value == 'Order with id 1 not found'
 
+@pytest.mark.usefixtures('order_details')
+def test_get_order_by_product_id(orders_rpc, order):
+    order_payload = OrderSchema().dump(order).data
+    first_product_id = order_payload['order_details'][0]['product_id']
+
+    response = orders_rpc.get_order_by_product_id(first_product_id)
+    assert response['id'] == order.id
+
 def test_list_orders(orders_rpc, order):
     response = orders_rpc.list_orders()
     assert response['items'][0]['id'] == order.id

--- a/products/products/dependencies.py
+++ b/products/products/dependencies.py
@@ -19,8 +19,6 @@ class StorageWrapper:
 
     """
 
-    NotFound = NotFound
-
     def __init__(self, client):
         self.client = client
 
@@ -44,7 +42,7 @@ class StorageWrapper:
         return self._from_hash(product)
 
     def list(self, product_ids=[]):
-        if product_ids == []:
+        if not product_ids:
             keys = self.client.scan_iter(count=1000)
         else:
             keys = {self._format_key(product_id) for product_id in product_ids}

--- a/products/products/dependencies.py
+++ b/products/products/dependencies.py
@@ -43,10 +43,16 @@ class StorageWrapper:
         
         return self._from_hash(product)
 
-    def list(self):
-        keys = self.client.keys(self._format_key('*'))
+    def list(self, product_ids=[]):
+        if product_ids == []:
+            keys = self.client.scan_iter(count=1000)
+        else:
+            keys = {self._format_key(product_id) for product_id in product_ids}
+
         for key in keys:
-            yield self._from_hash(self.client.hgetall(key))
+            document = self.client.hgetall(key)
+            if document:
+                yield (self._from_hash(document))
 
     def create(self, product):
         self.client.hmset(

--- a/products/products/dependencies.py
+++ b/products/products/dependencies.py
@@ -40,8 +40,8 @@ class StorageWrapper:
         product = self.client.hgetall(self._format_key(product_id))
         if not product:
             raise NotFound('Product ID {} does not exist'.format(product_id))
-        else:
-            return self._from_hash(product)
+        
+        return self._from_hash(product)
 
     def list(self):
         keys = self.client.keys(self._format_key('*'))
@@ -52,6 +52,13 @@ class StorageWrapper:
         self.client.hmset(
             self._format_key(product['id']),
             product)
+        
+    def delete(self, product_id):
+        keys_removed = self.client.delete(self._format_key(product_id))
+        if keys_removed == 0:
+            raise NotFound('Product ID {} does not exist'.format(product_id))
+        
+        return {'id': product_id}
 
     def decrement_stock(self, product_id, amount):
         return self.client.hincrby(

--- a/products/products/service.py
+++ b/products/products/service.py
@@ -30,6 +30,10 @@ class ProductsService:
         product = schemas.Product(strict=True).load(product).data
         self.storage.create(product)
 
+    @rpc
+    def delete(self, product_id):
+        self.storage.delete(product_id)
+
     @event_handler('orders', 'order_created')
     def handle_order_created(self, payload):
         for product in payload['order']['order_details']:

--- a/products/products/service.py
+++ b/products/products/service.py
@@ -21,8 +21,8 @@ class ProductsService:
         return schemas.Product().dump(product).data
 
     @rpc
-    def list(self):
-        products = self.storage.list()
+    def list(self, product_ids=[]):
+        products = self.storage.list(product_ids)
         return schemas.Product(many=True).dump(products).data
 
     @rpc

--- a/products/products/service.py
+++ b/products/products/service.py
@@ -3,7 +3,8 @@ import logging
 from nameko.events import event_handler
 from nameko.rpc import rpc
 
-from products import dependencies, schemas
+from products.dependencies import Storage
+from products.schemas import Product
 
 
 logger = logging.getLogger(__name__)
@@ -13,22 +14,23 @@ class ProductsService:
 
     name = 'products'
 
-    storage = dependencies.Storage()
+    storage = Storage()
 
     @rpc
     def get(self, product_id):
         product = self.storage.get(product_id)
-        return schemas.Product().dump(product).data
+        return Product().dump(product).data
 
     @rpc
     def list(self, product_ids=[]):
         products = self.storage.list(product_ids)
-        return schemas.Product(many=True).dump(products).data
+        return Product(many=True).dump(products).data
 
     @rpc
     def create(self, product):
-        product = schemas.Product(strict=True).load(product).data
+        product = Product(strict=True).load(product).data
         self.storage.create(product)
+        return product
 
     @rpc
     def delete(self, product_id):

--- a/products/test/conftest.py
+++ b/products/test/conftest.py
@@ -13,7 +13,7 @@ def test_config(rabbit_config):
         yield
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def redis_client(test_config):
     client = redis.StrictRedis.from_url(config.get(REDIS_URI_KEY))
     yield client

--- a/products/test/test_dependencies.py
+++ b/products/test/test_dependencies.py
@@ -32,6 +32,12 @@ def test_list(storage, products):
     listed_products = storage.list()
     assert (
         products == sorted(list(listed_products), key=lambda x: x['id']))
+    
+def test_list_filtering_by_product_ids(storage, products):
+    listed_products = storage.list(product_ids=['LZ129'])
+    product_ids = [product['id'] for product in listed_products]
+    assert len(product_ids) == 1
+    assert product_ids[0] == 'LZ129'
 
 
 def test_create(product, redis_client, storage):

--- a/products/test/test_dependencies.py
+++ b/products/test/test_dependencies.py
@@ -1,8 +1,9 @@
 import pytest
 from mock import Mock
-
 from nameko import config
+
 from products.dependencies import Storage
+from products.exceptions import NotFound
 
 
 @pytest.fixture
@@ -14,7 +15,7 @@ def storage(test_config):
 
 
 def test_get_fails_on_not_found(storage):
-    with pytest.raises(storage.NotFound) as exc:
+    with pytest.raises(NotFound) as exc:
         storage.get(2)
     assert 'Product ID 2 does not exist' == exc.value.args[0]
 
@@ -54,7 +55,7 @@ def test_create(product, redis_client, storage):
     assert product['in_stock'] == int(stored_product[b'in_stock'])
 
 def test_delete_fails_on_not_found(storage):
-    with pytest.raises(storage.NotFound) as exc:
+    with pytest.raises(NotFound) as exc:
         storage.delete(2)
     assert 'Product ID 2 does not exist' == exc.value.args[0]
 

--- a/products/test/test_dependencies.py
+++ b/products/test/test_dependencies.py
@@ -47,6 +47,17 @@ def test_create(product, redis_client, storage):
         int(stored_product[b'passenger_capacity']))
     assert product['in_stock'] == int(stored_product[b'in_stock'])
 
+def test_delete_fails_on_not_found(storage):
+    with pytest.raises(storage.NotFound) as exc:
+        storage.delete(2)
+    assert 'Product ID 2 does not exist' == exc.value.args[0]
+
+
+def test_delete(storage, redis_client, products):
+    storage.delete('LZ129')
+    
+    assert 0 == redis_client.exists('products:LZ129')
+
 
 def test_decrement_stock(storage, create_product, redis_client):
     create_product(id=1, title='LZ 127', in_stock=10)

--- a/products/test/test_service.py
+++ b/products/test/test_service.py
@@ -62,6 +62,22 @@ def test_create_product(product, redis_client, service_container):
         int(stored_product[b'passenger_capacity']))
     assert product['in_stock'] == int(stored_product[b'in_stock'])
 
+def test_delete_product(create_product, redis_client, service_container):
+
+    stored_product = create_product()
+
+    with entrypoint_hook(service_container, 'delete') as delete:
+        delete(stored_product['id'])
+
+    assert 0 == redis_client.exists('products:{}'.format(stored_product['id']))
+
+
+def test_delete_product_fails_on_not_found(service_container):
+
+    with pytest.raises(NotFound):
+        with entrypoint_hook(service_container, 'delete') as delete:
+            delete(111)
+
 
 @pytest.mark.parametrize('product_overrides, expected_errors', [
     ({'id': 111}, {'id': ['Not a valid string.']}),

--- a/products/test/test_service.py
+++ b/products/test/test_service.py
@@ -39,6 +39,13 @@ def test_list_products(products, service_container):
 
     assert products == sorted(listed_products, key=lambda p: p['id'])
 
+def test_list_products_with_filter(products, service_container):
+    with entrypoint_hook(service_container, 'list') as list_:
+        listed_products = list_(product_ids=['LZ127'])
+
+    assert len(listed_products) == 1
+    assert listed_products[0]['id'] == 'LZ127'
+
 
 def test_list_productis_when_empty(service_container):
 

--- a/test/nex-bzt.yml
+++ b/test/nex-bzt.yml
@@ -64,7 +64,52 @@ scenarios:
         product_key: $.id
         default: NOT_FOUND
 
-    # 3. Create Orders
+    # 3.1. Create Product to delete
+    - url: /products
+      label: products-create-to-delete
+      think-time: uniform(0s, 0s)
+      method: POST
+      headers:
+        cache-control: no-cache
+        Content-Type: application/json
+      body: 'request-body-string'
+      body: >
+        {
+          "id": "${id}-${__javaScript(Math.random())}-DEL",
+          "title": "${title}-DEL",
+          "passenger_capacity": ${passenger_capacity},
+          "maximum_speed": ${maximum_speed},
+          "in_stock": ${in_stock}
+        }          
+      assert:
+      - contains:
+        - 200
+        subject: http-code
+        not: false
+      extract-jsonpath:
+        product_id_to_delete: $.id
+        default: NOT_FOUND
+
+    - if: '"${product_id_to_delete}" == "NOT_FOUND"'
+      then:
+        - action: continue
+
+    # 3.2. Delete Product
+    - url: /products/${product_id_to_delete}
+      label: product-delete
+      think-time: uniform(0s, 0s)
+      method: DELETE
+        
+      assert:
+      - contains:
+        - 200
+        subject: http-code
+        not: false
+      extract-jsonpath:
+        product_id_deleted: $.id
+        default: NOT_FOUND
+
+    # 4. Create Order
     - url: /orders
       label: orders-create
       think-time: uniform(0s, 0s)
@@ -90,7 +135,7 @@ scenarios:
       then:
         - action: continue
   
-    # 4. Get Orders
+    # 5. Get Order
     - url: /orders/${order_id}
       label: order-get
       think-time: uniform(0s, 0s)
@@ -109,50 +154,31 @@ scenarios:
       then:
         - action: continue
 
-    # 5.1. Create Product for delete
-    - url: /products
-      label: products-create-for-delete
+    # 6.1 List Orders
+    - url: /orders
+      label: orders-list
       think-time: uniform(0s, 0s)
-      method: POST
-      headers:
-        cache-control: no-cache
-        Content-Type: application/json
-      body: 'request-body-string'
-      body: >
-        {
-          "id": "${id}-${__javaScript(Math.random())}-DEL",
-          "title": "${title}-DEL",
-          "passenger_capacity": ${passenger_capacity}-DEL,
-          "maximum_speed": ${maximum_speed}-DEL,
-          "in_stock": ${in_stock}-DEL
-        }          
-      assert:
-      - contains:
-        - 200
-        subject: http-code
-        not: false
-      extract-jsonpath:
-        product_id_for_delete: $.id
-        default: NOT_FOUND
-
-    - if: '"${product_id_for_delete}" == "NOT_FOUND"'
-      then:
-        - action: continue
-
-    # 5.2. Delete Product
-    - url: /products/${product_id_for_delete}
-      label: product-delete
-      think-time: uniform(0s, 0s)
-      method: DELETE
+      method: GET
         
       assert:
       - contains:
         - 200
         subject: http-code
         not: false
-      extract-jsonpath:
-        product_id_deleted: $.id
-        default: NOT_FOUND
+
+    # 6.2. List Orders with custom pagination
+    - url: /orders?page=2&page_size=80
+      label: orders-list-with-custom-pagination
+      think-time: uniform(0s, 0s)
+      method: GET
+        
+      assert:
+      - contains:
+        - 200
+        subject: http-code
+        not: false
+
+    
   
 reporting:
 - module: final-stats

--- a/test/nex-bzt.yml
+++ b/test/nex-bzt.yml
@@ -108,6 +108,51 @@ scenarios:
     - if: '"${order_id}" == "NOT_FOUND"'
       then:
         - action: continue
+
+    # 5.1. Create Product for delete
+    - url: /products
+      label: products-create-for-delete
+      think-time: uniform(0s, 0s)
+      method: POST
+      headers:
+        cache-control: no-cache
+        Content-Type: application/json
+      body: 'request-body-string'
+      body: >
+        {
+          "id": "${id}-${__javaScript(Math.random())}-DEL",
+          "title": "${title}-DEL",
+          "passenger_capacity": ${passenger_capacity}-DEL,
+          "maximum_speed": ${maximum_speed}-DEL,
+          "in_stock": ${in_stock}-DEL
+        }          
+      assert:
+      - contains:
+        - 200
+        subject: http-code
+        not: false
+      extract-jsonpath:
+        product_id_for_delete: $.id
+        default: NOT_FOUND
+
+    - if: '"${product_id_for_delete}" == "NOT_FOUND"'
+      then:
+        - action: continue
+
+    # 5.2. Delete Product
+    - url: /products/${product_id_for_delete}
+      label: product-delete
+      think-time: uniform(0s, 0s)
+      method: DELETE
+        
+      assert:
+      - contains:
+        - 200
+        subject: http-code
+        not: false
+      extract-jsonpath:
+        product_id_deleted: $.id
+        default: NOT_FOUND
   
 reporting:
 - module: final-stats

--- a/test/nex-bzt.yml
+++ b/test/nex-bzt.yml
@@ -154,7 +154,7 @@ scenarios:
       then:
         - action: continue
 
-    # 6.1 List Orders
+    # 6 List Orders
     - url: /orders
       label: orders-list
       think-time: uniform(0s, 0s)
@@ -165,20 +165,6 @@ scenarios:
         - 200
         subject: http-code
         not: false
-
-    # 6.2. List Orders with custom pagination
-    - url: /orders?page=2&page_size=80
-      label: orders-list-with-custom-pagination
-      think-time: uniform(0s, 0s)
-      method: GET
-        
-      assert:
-      - contains:
-        - 200
-        subject: http-code
-        not: false
-
-    
   
 reporting:
 - module: final-stats

--- a/test/nex-smoketest.sh
+++ b/test/nex-smoketest.sh
@@ -58,6 +58,12 @@ curl -s "${STD_APP_URL}/orders/${ID}" | jq .
 echo "=== Listing Order ==="
 curl -s "${STD_APP_URL}/orders?page=1&per_page=30" | jq .
 
-# Test: Delete Product
-echo "=== Deleting product id: the_odyssey ==="
-curl -s -XDELETE "${STD_APP_URL}/products/the_odyssey" | jq .
+# Test: Delete a Product
+echo "=== Creating a product id to be deleted: the_honda ==="
+curl -s -XPOST  "${STD_APP_URL}/products" \
+    -H 'accept: application/json' \
+    -H 'Content-Type: application/json' \
+    -d '{"id": "the_honda", "title": "The Honda", "passenger_capacity": 1, "maximum_speed": 1, "in_stock": 1}'
+echo
+echo "=== Deleting product id: the_honda ==="
+curl -s -XDELETE "${STD_APP_URL}/products/the_honda" | jq .

--- a/test/nex-smoketest.sh
+++ b/test/nex-smoketest.sh
@@ -54,6 +54,10 @@ ID=$(echo ${ORDER_ID} | jq '.id')
 echo "=== Getting Order ==="
 curl -s "${STD_APP_URL}/orders/${ID}" | jq .
 
+# Test: List Orders
+echo "=== Listing Order ==="
+curl -s "${STD_APP_URL}/orders?page=1&per_page=30" | jq .
+
 # Test: Delete Product
 echo "=== Deleting product id: the_odyssey ==="
 curl -s -XDELETE "${STD_APP_URL}/products/the_odyssey" | jq .

--- a/test/nex-smoketest.sh
+++ b/test/nex-smoketest.sh
@@ -34,6 +34,7 @@ curl -s -XPOST  "${STD_APP_URL}/products" \
     -H 'Content-Type: application/json' \
     -d '{"id": "the_odyssey", "title": "The Odyssey", "passenger_capacity": 101, "maximum_speed": 5, "in_stock": 10}'
 echo
+
 # Test: Get Product
 echo "=== Getting product id: the_odyssey ==="
 curl -s "${STD_APP_URL}/products/the_odyssey" | jq .
@@ -52,3 +53,7 @@ ID=$(echo ${ORDER_ID} | jq '.id')
 # Test: Get Order back
 echo "=== Getting Order ==="
 curl -s "${STD_APP_URL}/orders/${ID}" | jq .
+
+# Test: Delete Product
+echo "=== Deleting product id: the_odyssey ==="
+curl -s -XDELETE "${STD_APP_URL}/products/the_odyssey" | jq .


### PR DESCRIPTION
## Code Challenge
### Why is performance degrading as the test run longer?
In every `GET /orders/{id}` or `POST /orders` request, the gateway makes a RPC call to the Products service and gets all the products present in the database. This is done for validations before creating an order or to include product information in the response. But as the database grows, this request ends up taking longer to return since the volume of products present grows, thus causing performance degradation.

### How do you fix it?
Implementing a filter in the product service to search for product_ids and then requesting only the `product_ids` that are related to the order that needs to be validated or filled with product data.

## Implementation Notes
### Delete product call
I chose to use the HARD DELETE method to remove the product, but considering that before this operation, a validation is performed at the gateway, checking whether the product has an order related to it to maintain data integrity. However if as a rule the product must be deleted even if it is present in an order then I would choose to use SOFT DELETE thus also maintaining the integrity of the data.

### List orders call
I chose to use a listing with pagination through `OFFSET` and `LIMIT` because if the endpoint returned all orders in each request, this would also generate a bottleneck and degradation of performance in the system. There are other paging methods to be taken into account such as `CURSOR` and `KEYSET` but it will depend on the use of this listing by the system.

### Extra note
The [Redis documentation](https://redis.io/commands/keys/) warns about the use of KEYS in production so I changed its use to SCAN in case there is a need to request for all products in the database.